### PR TITLE
fix: timestamp conversion on 32bit systems

### DIFF
--- a/fnordmetric-core/src/sql/svalue.cc
+++ b/fnordmetric-core/src/sql/svalue.cc
@@ -470,7 +470,7 @@ bool SValue::tryTimeConversion() {
   time_t ts = getInteger();
   data_.type = T_TIMESTAMP;
   // FIXPAUL take a smart guess if this is milli, micro, etc
-  data_.u.t_timestamp = ts * 1000000;
+  data_.u.t_timestamp = ts * 1000000llu;
   return true;
 }
 

--- a/fnordmetric-core/src/util/wallclock.cc
+++ b/fnordmetric-core/src/util/wallclock.cc
@@ -25,7 +25,7 @@ uint64_t WallClock::unixMillis() {
   struct timeval tv;
 
   gettimeofday(&tv, NULL);
-  return tv.tv_sec * 1000u + tv.tv_usec / 1000u;
+  return tv.tv_sec * 1000llu + tv.tv_usec / 1000llu;
 }
 
 uint64_t WallClock::getUnixMicros() {
@@ -36,7 +36,7 @@ uint64_t WallClock::unixMicros() {
   struct timeval tv;
 
   gettimeofday(&tv, NULL);
-  return tv.tv_sec * 1000000u + tv.tv_usec;
+  return tv.tv_sec * 1000000llu + tv.tv_usec;
 }
 
 }


### PR DESCRIPTION
On Systems where `<bits/typesizes.h>` has 
`#define __TIME_T_TYPE           __SLONGWORD_TYPE`
some conversions to 64bit types are truncated.
